### PR TITLE
feat: add system uptime information

### DIFF
--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -233,6 +233,7 @@ sudo resolvectl status >"${NETWORKING_DIR}/resolvectl-status.txt"
 top -n 1 -b >"${FINAL_DIR}/top.txt"
 nvidia-smi >"${FINAL_DIR}/nvidia-smi.txt"
 ss --tcp --udp --listening --numeric >"${NETWORKING_DIR}/ss.txt"
+echo "$(uptime -p)" since "$(uptime -s)" >"${FINAL_DIR}/uptime.txt"
 
 collect_drive_checks
 


### PR DESCRIPTION
The collector didn't previously include explicit uptime information, which meant identifying system uptime required additional manual work. This adds the most recent boot time and the current running uptime to a dedicated file.