### PR TITLE
Add GPU serial to bus mappings

### DIFF
--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -232,6 +232,7 @@ sudo ufw status >"${NETWORKING_DIR}/ufw-status.txt"
 sudo resolvectl status >"${NETWORKING_DIR}/resolvectl-status.txt"
 top -n 1 -b >"${FINAL_DIR}/top.txt"
 nvidia-smi >"${FINAL_DIR}/nvidia-smi.txt"
+nvidia-smi -q | grep -E "Serial Number|Bus Id" >"${FINAL_DIR}/gpu-serials.txt"
 ss --tcp --udp --listening --numeric >"${NETWORKING_DIR}/ss.txt"
 echo "$(uptime -p)" since "$(uptime -s)" >"${FINAL_DIR}/uptime.txt"
 


### PR DESCRIPTION
The tool did not previously include a clean list of what GPU serials are installed or where they are installed. Now it does.