### PR TITLE
Minimize Bug Report Impact to Target

### DIFF
--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -43,7 +43,14 @@ check_if_virtualized() {
 
 check_if_virtualized
 
+# By default, do not install tools.
+SKIP_TOOLS=${SKIP_TOOLS:-1}
+
 install_needed_tool() {
+    if [ $SKIP_TOOLS -eq 1 ]; then
+        # The script has been told not to install tools, no need to proceed further with this fuction.
+        return
+    fi
     if [ $IS_VIRTUAL_MACHINE -eq 0 ]; then
         # The tool is not beneficial for a VM, no need to proceed further with this fuction.
         return
@@ -132,14 +139,7 @@ sudo dmesg -Tl err >"${SYSTEM_LOGS_DIR}/dmesg-errors.txt"
 sudo journalctl >"${SYSTEM_LOGS_DIR}/journalctl.txt"
 
 # Check for ibstat and install if not present
-if ! command -v ibstat >/dev/null 2>&1; then
-    echo "ibstat could not be found, attempting to install."
-    if [ "$APT_UPDATE_HAS_RUN" != "True" ]; then
-        sudo apt-get update >/dev/null 2>&1
-        APT_UPDATE_HAS_RUN=True
-    fi
-    sudo apt-get install -y infiniband-diags >/dev/null 2>&1
-fi
+install_needed_tool ibstat infiniband-diags
 ibstat >"${FINAL_DIR}/ibstat.txt"
 if [ ! -s "${FINAL_DIR}/ibstat.txt" ]; then
     echo "No InfiniBand data available. This machine may not have InfiniBand." >"${FINAL_DIR}/ibstat.txt"
@@ -161,25 +161,11 @@ install_needed_tool sensors lm-sensors
 sensors >"${FINAL_DIR}/sensors.txt" 2>/dev/null
 
 # Check for iostat and install if not present
-if ! command -v iostat >/dev/null 2>&1; then
-    echo "iostat could not be found, attempting to install."
-    if [ "$APT_UPDATE_HAS_RUN" != "True" ]; then
-        sudo apt-get update >/dev/null 2>&1
-        APT_UPDATE_HAS_RUN=True
-    fi
-    sudo apt-get install -y sysstat >/dev/null 2>&1
-fi
+install_needed_tool iostat sysstat
 sudo iostat -xt >"${DRIVES_AND_STORAGE_DIR}/iostat.txt"
 
 # Check for lshw and install if not present
-if ! command -v lshw >/dev/null 2>&1; then
-    echo "lshw could not be found, attempting to install."
-    if [ "$APT_UPDATE_HAS_RUN" != "True" ]; then
-        sudo apt-get update >/dev/null 2>&1
-        APT_UPDATE_HAS_RUN=True
-    fi
-    sudo apt-get install -y lshw >/dev/null 2>&1
-fi
+install_needed_tool lshw lshw
 sudo lshw >"${FINAL_DIR}/hw-list.txt"
 
 # Collect SW Raid info

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -202,13 +202,22 @@ fi
 
 # Check for memory remapping and memory errors on GPUs
 nvidia-smi --query-remapped-rows=gpu_bus_id,gpu_uuid,remapped_rows.correctable,remapped_rows.uncorrectable,remapped_rows.pending,remapped_rows.failure \
-    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/remapped-memory.txt"
+    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/remapped-memory.txt" 2>&1
+if [ ! -s "${GPU_MEMORY_ERRORS_DIR}/remapped-memory.txt" ]; then
+    echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${GPU_MEMORY_ERRORS_DIR}/remapped-memory.txt"
+fi
 
 nvidia-smi --query-gpu=index,pci.bus_id,uuid,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.volatile.sram \
-    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/ecc-errors.txt"
+    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/ecc-errors.txt" 2>&1
+if [ ! -s "${GPU_MEMORY_ERRORS_DIR}/ecc-errors.txt" ]; then
+    echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${GPU_MEMORY_ERRORS_DIR}/ecc-errors.txt"
+fi
 
 nvidia-smi --query-gpu=index,pci.bus_id,uuid,ecc.errors.uncorrected.aggregate.dram,ecc.errors.uncorrected.aggregate.sram \
-    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/uncorrected-ecc_errors.txt"
+    --format=csv >"${GPU_MEMORY_ERRORS_DIR}/uncorrected-ecc_errors.txt" 2>&1
+if [ ! -s "${GPU_MEMORY_ERRORS_DIR}/uncorrected-ecc_errors.txt" ]; then
+    echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${GPU_MEMORY_ERRORS_DIR}/uncorrected-ecc_errors.txt"
+fi
 
 # Check hibernation settings
 sudo systemctl status hibernate.target hybrid-sleep.target \
@@ -246,7 +255,10 @@ sudo iptables -L --line-numbers >"${NETWORKING_DIR}/iptables.txt"
 sudo ufw status >"${NETWORKING_DIR}/ufw-status.txt"
 sudo resolvectl status >"${NETWORKING_DIR}/resolvectl-status.txt"
 top -n 1 -b >"${FINAL_DIR}/top.txt"
-nvidia-smi >"${FINAL_DIR}/nvidia-smi.txt"
+nvidia-smi >"${FINAL_DIR}/nvidia-smi.txt" 2>&1
+if [ ! -s "${FINAL_DIR}/nvidia-smi.txt" ]; then
+    echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${FINAL_DIR}/nvidia-smi.txt"
+fi
 sudo ss --tcp --udp --listening --numeric --process >"${NETWORKING_DIR}/ss.txt"
 echo "$(uptime -p)" since "$(uptime -s)" >"${FINAL_DIR}/uptime.txt"
 

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -30,14 +30,14 @@ script_info_and_disclaimer
 
 # We will later check whether this machine will benefit from certain tools, rather than just installing them.
 # Proactively assume the machine is not a VM
-IS_VIRTUAL_MACHINE=1
+IS_VIRTUAL_MACHINE=0
 
 check_if_virtualized() {
     SYSTEM_MANUFACTURER="$(sudo dmidecode | grep -A1 "System Information" | grep "Manufacturer" | sed 's/^\tManufacturer: //')"
     if [[ "${SYSTEM_MANUFACTURER}" == "QEMU" ]]; then
-        IS_VIRTUAL_MACHINE=0
-    else
         IS_VIRTUAL_MACHINE=1
+    else
+        IS_VIRTUAL_MACHINE=0
     fi
 }
 
@@ -51,7 +51,7 @@ install_needed_tool() {
         # The script has been told not to install tools, no need to proceed further with this fuction.
         return
     fi
-    if [ $IS_VIRTUAL_MACHINE -eq 0 ]; then
+    if [ $IS_VIRTUAL_MACHINE -eq 1 ]; then
         # The tool is not beneficial for a VM, no need to proceed further with this fuction.
         return
     fi

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -47,11 +47,19 @@ check_if_virtualized
 SKIP_TOOLS=${SKIP_TOOLS:-1}
 
 install_needed_tool() {
+    # Usage: install_needed_tool <executable> <package> [0|1]
+    # <executable> is the executable to check to determine if a package needs to be installed
+    # <package> is the package to install if the previous check fails
+    # the third field determines whether this tool is useful on a VM (0 for no, 1 for yes)
+
+    # Proactively assume a tool is not beneficial on a VM
+    VM_TOOL=${3:-0}
+
     if [ $SKIP_TOOLS -eq 1 ]; then
         # The script has been told not to install tools, no need to proceed further with this fuction.
         return
     fi
-    if [ $IS_VIRTUAL_MACHINE -eq 1 ]; then
+    if [[ $IS_VIRTUAL_MACHINE -eq 1 && $VM_TOOL -eq 0 ]]; then
         # The tool is not beneficial for a VM, no need to proceed further with this fuction.
         return
     fi
@@ -139,7 +147,7 @@ sudo dmesg -Tl err >"${SYSTEM_LOGS_DIR}/dmesg-errors.txt"
 sudo journalctl >"${SYSTEM_LOGS_DIR}/journalctl.txt"
 
 # Check for ibstat and install if not present
-install_needed_tool ibstat infiniband-diags
+install_needed_tool ibstat infiniband-diags 1
 ibstat >"${FINAL_DIR}/ibstat.txt"
 if [ ! -s "${FINAL_DIR}/ibstat.txt" ]; then
     echo "No InfiniBand data available. This machine may not have InfiniBand." >"${FINAL_DIR}/ibstat.txt"
@@ -161,11 +169,11 @@ install_needed_tool sensors lm-sensors
 sensors >"${FINAL_DIR}/sensors.txt" 2>/dev/null
 
 # Check for iostat and install if not present
-install_needed_tool iostat sysstat
+install_needed_tool iostat sysstat 1
 sudo iostat -xt >"${DRIVES_AND_STORAGE_DIR}/iostat.txt"
 
 # Check for lshw and install if not present
-install_needed_tool lshw lshw
+install_needed_tool lshw lshw 1
 sudo lshw >"${FINAL_DIR}/hw-list.txt"
 
 # Collect SW Raid info

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -150,8 +150,6 @@ done
 sudo dmesg -Tl err >"${SYSTEM_LOGS_DIR}/dmesg-errors.txt"
 sudo journalctl >"${SYSTEM_LOGS_DIR}/journalctl.txt"
 
-# Check for ibstat and install if not present
-install_needed_tool ibstat infiniband-diags 1
 ibstat >"${FINAL_DIR}/ibstat.txt" 2>/dev/null
 if [ ! -s "${FINAL_DIR}/ibstat.txt" ]; then
     echo "No InfiniBand data available. This machine may not have InfiniBand." >"${FINAL_DIR}/ibstat.txt"

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -259,7 +259,10 @@ nvidia-smi >"${FINAL_DIR}/nvidia-smi.txt" 2>&1
 if [ ! -s "${FINAL_DIR}/nvidia-smi.txt" ]; then
     echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${FINAL_DIR}/nvidia-smi.txt"
 fi
-nvidia-smi -q | grep -E "Serial Number|Bus Id" >"${FINAL_DIR}/gpu-serials.txt"
+nvidia-smi -q | grep -E "Serial Number|Bus Id" >"${FINAL_DIR}/gpu-serials.txt" 2>&1
+if [ ! -s "${FINAL_DIR}/gpu-serials.txt" ]; then
+    echo "No nvidia-smi data available. This machine may not have nvidia-smi." >"${FINAL_DIR}/gpu-serials.txt"
+fi
 sudo ss --tcp --udp --listening --numeric --process >"${NETWORKING_DIR}/ss.txt"
 echo "$(uptime -p)" since "$(uptime -s)" >"${FINAL_DIR}/uptime.txt"
 


### PR DESCRIPTION
The bug report had the potential to install a handful of tools if not detected on the machine, including the following:
* ibstat (part of infiniband-diags)
* ipmitool (part of ipmitool)
* iostat (part of sysstat)
* lshw (part of lshw)
* sensors (part of lm-sensors)
* smartctl (part of smartmontools)

In addition to the comments raised by Josh. in https://github.com/lambdal-support/lambda-public-tools/pull/2#issuecomment-2332194673 about not installing software on instances, some of these tools are not always useful. For example, a cloud instance won't benefit from ipmitool or smartmontools because they are virtualized.

This PR establishes a few new behaviors:
1. it will, by default, not install any tools (setting the environment variable SKIP_TOOLS to 0 will override)
2. it will not install to a detected cloud instance any tools which would provide no benefit there
3. it functionalizes tool installation and the above checks instead of repeating code
4. it will gracefully (read: silently) handle tools that cannot be run where they may not be installed

I have also removed the install check for `infiniband-diags`, since to my knowledge any machine without `rmda-core` can't use IB and the latter package depends on the former.  I'm open to correction on this. I lastly modified the `nvidia-smi` parts to gracefully deal with `nvidia-smi` not being present. Even though they are not being install checked by the script, CPU nodes for example might not have it.

I did not remove it, but the install check for `lshw` is probably unnecessary. Both it and `dmidecode` are dependencies of `ubuntu-standard` and I suspect it will always be available. This might be something for future review. There are other enhancements I'd like to make to improve maintainability and readability that I chose not to include in this PR to keep it focused on one subject.