### PR TITLE
Functionalize Tool Checks and Installs

### DIFF
--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -127,9 +127,6 @@ mkdir -p "$BMC_INFO_DIR"
 GRUB_DIR="$FINAL_DIR/grub"
 mkdir -p "$GRUB_DIR"
 
-#Global variables
-APT_UPDATE_HAS_RUN=False
-
 # Collect SMART data for all drives
 collect_drive_checks() {
     lsblk -o NAME,MAJ:MIN,RM,SIZE,RO,FSTYPE,LABEL,UUID,TYPE,MOUNTPOINT >"$DRIVES_AND_STORAGE_DIR/lsblk.txt"

--- a/lambda-bug-report.sh
+++ b/lambda-bug-report.sh
@@ -76,9 +76,9 @@ install_needed_tools() {
         set -- $(echo ${NEEDED_TOOLS[${CURRENT_TOOL}]} | tr -d ',')
 
         # Proactively assume a tool is not beneficial on a VM
-        VM_TOOL=${3:-0}
+        IS_VM_TOOL=${3:-0}
 
-        if [[ $IS_VIRTUAL_MACHINE -eq 1 && $VM_TOOL -eq 0 ]]; then
+        if [[ $IS_VIRTUAL_MACHINE -eq 1 && $IS_VM_TOOL -eq 0 ]]; then
             # The tool is not beneficial for a VM, no need to proceed further with this iteration of the loop.
             CURRENT_TOOL=$((${CURRENT_TOOL}+1))
             continue


### PR DESCRIPTION
Previously, to install tools authors had to call a function with the relevant binary to check for, package name, and whether the tool was useful on a VM. Now, authors need only add this information to a dedicated array in the script. The script will still handle checking whether it should perform installs at all, whether the tool is available, and whether the tool is likely to be useful on a VM before proceeding. This array can be trivially expanded with more tool metadata in the future if needed.

The array is also referenced to provide users with a dynamic list of packages that may, optionally, be installed to collect diagnostic information about their machine. Previously this list was hard-coded. The text provided to the user is now clear that these installs are optional, but I did not elect to specify how to opt-in since I think it would be best to have that be under advisement from whomever they are working with in support (since support is the best qualified to determine whether they need to install these tools.)

Relevant function calls have been moved so they are not called before data they rely on is available.